### PR TITLE
Replace internal runtime function %FunctionSetName

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -3,6 +3,6 @@ exports.SetCode = function(a, b) {
 };
 
 exports.FunctionSetName = function(a, b) {
-	%FunctionSetName(a, b);
+	Object.defineProperty(a, 'name', { value: b });
 };
 


### PR DESCRIPTION
We are using the internal runtime function `%FunctionSetName` at `runtime.js`, but [since v8 version 6.1](https://github.com/nodejs/node/pull/15393/commits/a753f9ddda956d0b162e214564dd2b42c4e8c108#diff-48b50985e58265351753c441f8a7d9b5L234) this internal function doesn't exist anymore, then we can't use newer Node versions with Saphire.

This PR fix it replacing `%FunctionSetName(a, b)` with an equivalent code: `Object.defineProperty(a, 'name', { value: b });`